### PR TITLE
Update tests

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,13 +14,16 @@ BufferedStream = function (limit) {
   this.readable = true;
 }
 util.inherits(BufferedStream, stream.Stream);
+BufferedStream.prototype.bufferSize = function() {
+  return this.chunks.length;
+}
 BufferedStream.prototype.pipe = function () {
   var dest = this.dest = arguments[0];
   if (this.resume) this.resume();
   stream.Stream.prototype.pipe.apply(this, arguments);
   this.chunks.forEach(function (c) {dest.write(c)})
   this.size = 0;
-  delete this.chunks;
+  this.chunks = [];
 }
 BufferedStream.prototype.write = function (chunk) {
   if (this.dest) {

--- a/tests.js
+++ b/tests.js
@@ -2,34 +2,68 @@ var streams = require('./main')
   , assert = require('assert')
   , stream = require('stream')
   ;
-  
+
 var source = new stream.Stream()
   , dest = new stream.Stream()
   , buffered = new streams.BufferedStream()
   ;
 
+// Set up the source stream
+// It should emit 100 data events
+// It needs to emit end eventually
+// so we can check the results
 source.readable = true
-dest.writable = true
-
 source.pause = function () {
   throw new Error("Pause should not be called")
 }
 source.pipe(buffered)
 var i = 0;
 
-while (i !== 100) {
-  source.emit("data", "asdf")
-  i++
+// emit half now, these should be buffered
+while (i < 50) {
+  source.emit("data", 'before');
+  i++;
 }
 
-assert.ok(buffered.chunks.length === 100);
+// 50 data chunks buffered so far
+assert.ok(buffered.bufferSize() === 50);
 
+// Set up the destination stream
+// It should eventually receive 100 writes
 i = 0;
-dest.write = function () {
-  i++
+dest.writable = true
+dest.write = function(chunk) {
+  this.emit('data', chunk);
+  i++;
 }
+dest.end = function() { this.emit('end'); }
 
-buffered.pipe(dest)
+// The first data events should be from the
+// previously buffered ones.
+dest.on('data', function(chunk) {
+    console.error(i, chunk);
+    if( i < 50 )
+        assert.equal('before', chunk);
+    else
+        assert.equal('after', chunk);
+});
 
-assert.ok(i === 100);
+// Check the results on end
+dest.on('end', function() {
+    assert.ok(i === 100);
+    assert.ok(buffered.bufferSize() === 0);
+});
 
+setTimeout( function() {
+    // Now open the pipe and stream to the destination
+    // make sure end is called
+    buffered.pipe(dest, {end: true});
+
+    // emit the other half after some async event
+    while (i < 100) {
+        source.emit("data", "after");
+    }
+
+    // end so we can check the results
+    source.emit('end');
+}, 1000);


### PR DESCRIPTION
I updated the tests to exhibit asynchronous behavior with piping.  I added a bufferSize method to get current size of the buffer. It was the only place that the implementation of the buffering leaked through.
